### PR TITLE
Add support for proxy attribute passed via the rest client config hash

### DIFF
--- a/lib/JIRA/REST.pm
+++ b/lib/JIRA/REST.pm
@@ -48,7 +48,21 @@ sub new {
     is_hash_ref($rest_client_config)
         or croak __PACKAGE__ . "::new: REST_CLIENT_CONFIG argument must be a hash-ref.\n";
 
+    # remove the rest client faux config value 'proxy' if set and use
+    # it ourselves.
+    my $proxy;
+    if ( defined( $proxy = delete $rest_client_config->{proxy} ) ) {
+        $proxy = URI->new($proxy) if is_string($proxy);
+        is_instance($proxy, 'URI')
+            or croak __PACKAGE__ . "::new: proxy rest client attribute must be a string or a URI object.\n";
+    }
+
     my $rest = REST::Client->new($rest_client_config);
+
+    # Set proxy to be used
+    if ( $proxy ) {
+        $rest->getUseragent->proxy( ['http','https'] => $proxy->as_string );
+    }
 
     # Set default base URL
     $rest->setHost($URL);
@@ -369,6 +383,12 @@ A JIRA::REST object uses a REST::Client object to make the REST
 invocations. This optional argument must be a hash-ref that can be fed
 to the REST::Client constructor. Note that the C<URL> argument
 overwrites any value associated with the C<host> key in this hash.
+
+To use a network proxy please set the 'proxy' argument to the string
+or URI object describing the fully qualified (including port) URL to
+your network proxy. This is an extension to the REST::Client
+configuration and will be removed before passing on to the
+REST::Client constructor.
 
 =back
 


### PR DESCRIPTION
Rest::Client doesn't support providing a proxy in its config hash so a little extra work is needed to support passing this through.

Happy to move the proxy specification to be a top level argument to JIRA::REST::new() but this seemed the easiest way without changing the current interface.
