### PR TITLE
Minor POD modifications

### DIFF
--- a/lib/JIRA/REST.pm
+++ b/lib/JIRA/REST.pm
@@ -446,7 +446,7 @@ endpoints have a path prefix of C</rest/agile/VERSION>.
 =head2 new URL, USERNAME, PASSWORD, REST_CLIENT_CONFIG, ANONYMOUS, PROXY, SSL_VERIFY_NONE
 
 The constructor can take its arguments from a single hash reference or from
-a list of positional parameters. The first form is prefered because it lets
+a list of positional parameters. The first form is preferred because it lets
 you specify only the arguments you need. The second form forces you to pass
 undefined values if you need to pass a specific value to an argument further
 to the right.
@@ -548,7 +548,7 @@ fields, you pass C</rest/api/latest/field>, and in order to get SLA
 information about an issue you pass
 C</rest/servicedeskapi/request/$key/sla>.
 
-If you're using a method form JIRA Core REST API you may ommit the prefix
+If you're using a method form JIRA Core REST API you may omit the prefix
 C</rest/api/VERSION>. For example, to GET the list of all fields you may
 pass just C</field>.
 

--- a/lib/JIRA/REST.pm
+++ b/lib/JIRA/REST.pm
@@ -468,7 +468,11 @@ use (C</rest/api/VERSION>, C</rest/servicedeskapi>, or
 C</rest/agile/VERSION>). However, you may specify a default API prefix by
 suffixing the URL with it. For example:
 
-    my $jira = JIRA::REST->new('https://jira.example.net/jira/rest/api/1', 'myuser', 'mypass');
+    my $jira = JIRA::REST->new({
+        url      => 'https://jira.example.net/jira/rest/api/1',
+        username => 'myuser',
+        password => 'mypass'
+    });
 
     $jira->GET('/rest/api/1/issue/TST-1');
     $jira->GET('/issue/TST-1');

--- a/lib/JIRA/REST.pm
+++ b/lib/JIRA/REST.pm
@@ -442,6 +442,7 @@ endpoints have a path prefix of C</rest/agile/VERSION>.
 =head1 CONSTRUCTOR
 
 =head2 new HASHREF
+
 =head2 new URL, USERNAME, PASSWORD, REST_CLIENT_CONFIG, ANONYMOUS, PROXY, SSL_VERIFY_NONE
 
 The constructor can take its arguments from a single hash reference or from
@@ -478,6 +479,7 @@ a particular API or if you want to specify a particular version of an API
 during construction.
 
 =item * B<username>
+
 =item * B<password>
 
 The username and password of a JIRA user to use for authentication.


### PR DESCRIPTION
Looking over the POD, noticed three things:
- The constructor header shows up as "**new HASHREF =head2 new URL, USERNAME, PASSWORD, REST_CLIENT_CONFIG, ANONYMOUS, PROXY, SSL_VERIFY_NONE**"
- One of the constructor's arguments shows up as "**username** =item * **password**"
- The first paragraph of the constructor POD says "The [hashref] form [of the constructor] is preferred", but the sample code under "url" demonstrating how to specify a default API prefix still uses the positional argument form.

My spellchecker also flagged two typos for me, so I fixed them, too.