### PR TITLE
Make sure utf-8-encoded filenames and up correctly in JIRA

### DIFF
--- a/lib/JIRA/REST.pm
+++ b/lib/JIRA/REST.pm
@@ -355,7 +355,7 @@ sub attach_files {
             %{$rest->{_headers}},
             'X-Atlassian-Token' => 'nocheck',
             'Content-Type'      => 'form-data',
-            'Content'           => [ file => [$file] ],
+            'Content'           => [ file => [$file, Encode::encode_utf8( $file )] ],
         );
 
         $response->is_success


### PR DESCRIPTION
I don't know whether JIRA or HTTP::Request::Common are to blame, but
when I try do upload a file with accented characters in its name,
the file ends up having a �-infected name in JIRA. This little
patch fixes this bug. At least for me.