### PR TITLE
Correct the github-repository-uri in the metadata

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -36,6 +36,6 @@ Net::Netrc = 0
 
 [MetaResources]
 homepage        = https://metacpan.org/module/JIRA::REST
-repository.web  = https://github.com/gnustavo/gerrit-rest
+repository.web  = https://github.com/gnustavo/jira-rest
 repository.url  = https://github.com/gnustavo/JIRA-REST.git
 repository.type = git


### PR DESCRIPTION
So that metacpan.org will show the correct link when you click on "Repository"
or "git clone"