### PR TITLE
Avoid split mime64 string into multiple lines

### DIFF
--- a/lib/JIRA/REST.pm
+++ b/lib/JIRA/REST.pm
@@ -89,7 +89,7 @@ sub new {
 
     # Since Jira doesn't send an authentication challenge, we force the
     # sending of the authentication header.
-    $rest->addHeader(Authorization => 'Basic ' . encode_base64("$args{username}:$args{password}"))
+    $rest->addHeader(Authorization => 'Basic ' . encode_base64("$args{username}:$args{password}", ''))
         unless $args{anonymous};
 
     for my $ua ($rest->getUseragent) {


### PR DESCRIPTION
Recently I ran into an issue with jira rest api authentiaction.

After some investigations, I noticed `encode_base64` of the user and password introduces a new line character by default https://metacpan.org/pod/MIME::Base64#encode_base64(-$bytes-), and this breaks the authentication.

Hope this helps

