### PR TITLE
[doc] `REST.pm`: Swap `POST` and `PUT` to match descriptions

### DIFF
--- a/lib/JIRA/REST.pm
+++ b/lib/JIRA/REST.pm
@@ -719,11 +719,11 @@ Returns the RESOURCE as a Perl data structure.
 
 Deletes the RESOURCE.
 
-=head2 PUT RESOURCE, QUERY, VALUE [, HEADERS]
+=head2 POST RESOURCE, QUERY, VALUE [, HEADERS]
 
 Creates RESOURCE based on VALUE.
 
-=head2 POST RESOURCE, QUERY, VALUE [, HEADERS]
+=head2 PUT RESOURCE, QUERY, VALUE [, HEADERS]
 
 Updates RESOURCE based on VALUE.
 


### PR DESCRIPTION
`POST` creates, `PUT` updates with HTTP

In the examples `PUT` is (rightfully) used for editing:

https://github.com/gnustavo/JIRA-REST/blob/5de3eb67533868dbe821795a0bde2268b2cee0cf/examples/edit_issue.pl#L50